### PR TITLE
Set X-Forwarded-Port header to fix rack middleware

### DIFF
--- a/templates/nginx/pow.conf.erb
+++ b/templates/nginx/pow.conf.erb
@@ -6,6 +6,7 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Port $server_port;
     proxy_redirect off;
     proxy_pass http://localhost:<%= @http_port%>; # The real pow port
   }


### PR DESCRIPTION
Rack middleware currently generates incorrect URLs when serving an app through pow with this module. During a request to `http://myapp.pow`, calling `Rack::Request#url` produces `http://myapp.pow:30559`.

Rack is incorrectly using the port that pow is listening for proxied connections on. This header tells rack what the original port that the end user connected to was, which lets it generate the right URLs.
