### PR TITLE
fix(nginx) Sets X-Forwared-Host header to fix omniauth redirect mismatch

### DIFF
--- a/templates/nginx/pow.conf.erb
+++ b/templates/nginx/pow.conf.erb
@@ -5,6 +5,7 @@ server {
   location / {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_redirect off;
     proxy_pass http://localhost:<%= @http_port%>; # The real pow port


### PR DESCRIPTION
Trying to setup a boxen-web development with pow I was getting the oauth `redirect_uri_mismatch` error when trying to authenticate with github.

To solve that I've added the X-Forwarded-Host header to the nginx template
