### PR TITLE
fix(nginx) Sets client_max_body_size to a high value to prevent error when

### DIFF
--- a/templates/nginx/pow.conf.erb
+++ b/templates/nginx/pow.conf.erb
@@ -3,6 +3,8 @@ server {
   listen  80;
   server_name <%= @domains.split(',').map{|x| "*.#{x.strip}"}.join(" ") %>;
   location / {
+    client_max_body_size 200M;
+
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
uploading large files