### PR TITLE
Don't resolve the dev domain because dnsmasq already does

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -124,8 +124,9 @@ class pow(
       require => Package['boxen/brews/pow']
     }
 
-    # Add the dns resolver for each domain
-    $pow_domain_resolvers = prefix($pow_domains, '/etc/resolver/')
+    # Add the dns resolver for each domain except dev because dnsmasq did
+    $domains_without_dev  = delete($pow_domains, 'dev')
+    $pow_domain_resolvers = prefix($domains_without_dev, '/etc/resolver/')
 
     file { $pow_domain_resolvers:
       content => template('pow/resolver.erb'),


### PR DESCRIPTION
Setting dev as the domain causes a conflict with dnsmasq because they both write to `/etc/resolver/dev`. This seems to be the only issue preventing the use of dev.