### PR TITLE
Update Pow Brew file to include SHA256 hash

### DIFF
--- a/files/brews/pow.rb
+++ b/files/brews/pow.rb
@@ -1,20 +1,38 @@
 require 'formula'
 
 class Pow < Formula
-  homepage 'http://pow.cx/'
+  desc "Zero-config Rack server for local apps on OS X"
+  homepage "http://pow.cx/"
   url "http://get.pow.cx/versions/0.5.0.tar.gz"
-  sha1 "ef44f886a444340b91fb28e2fab3ce5471837a08"
+  sha256 "2e5f74d7c2f44004eb722eddf37356cd09b5563fde987b4c222fa6947ce388b7"
   version '0.5.0-boxen1'
 
-  depends_on 'node'
+  bottle :unneeded
+
+  depends_on "node"
 
   def install
-    libexec.install Dir['*']
-    (bin/'pow').write <<-EOS.undent
+    libexec.install Dir["*"]
+    (bin/"pow").write <<-EOS.undent
       #!/bin/sh
-      export POW_BIN="#{HOMEBREW_PREFIX}/bin/pow"
-      exec "#{HOMEBREW_PREFIX}/bin/node" "#{libexec}/lib/command.js" "$@"
+      export POW_BIN="#{bin}/pow"
+      exec "#{Formula["node"].opt_bin}/node" "#{libexec}/lib/command.js" "$@"
     EOS
   end
 
+  def caveats
+    <<-EOS.undent
+      Create the required host directories:
+        mkdir -p ~/Library/Application\\ Support/Pow/Hosts
+        ln -s ~/Library/Application\\ Support/Pow/Hosts ~/.pow
+
+      Setup port 80 forwarding and launchd agents:
+        sudo pow --install-system
+        pow --install-local
+
+      Load launchd agents:
+        sudo launchctl load -w /Library/LaunchDaemons/cx.pow.firewall.plist
+        launchctl load -w ~/Library/LaunchAgents/cx.pow.powd.plist
+    EOS
+  end
 end


### PR DESCRIPTION
Homebrew is deprecating all SHA1 hashes in favor of SHA256. The
version of the Pow Homebrew formula we had still had a SHA1 hash
which led to lots of deprication warnings and stuff. This updates the
formula to have a SHA256 hash. New formula from homebrew core here
(https://github.com/Homebrew/homebrew-core/blob/master/Formula/pow.rb)

It keeps the version number the same as it was before, since that has
a boxen post-fix.
